### PR TITLE
Mapping key must be a string scalar rather than number in Responses map

### DIFF
--- a/build.go
+++ b/build.go
@@ -156,15 +156,15 @@ func makeRequestBodyMap(reqBody *RequestBody) map[string]interface{} {
 	return reqBodyMap
 }
 
-func makeResponsesMap(responses *Responses) map[uint]interface{} {
-	responsesMap := make(map[uint]interface{}, len(*responses))
+func makeResponsesMap(responses *Responses) map[string]interface{} {
+	responsesMap := make(map[string]interface{}, len(*responses))
 
 	for _, resp := range *responses {
 		codeBodyMap := make(map[string]interface{})
 		codeBodyMap[keyDescription] = resp.Description
 		codeBodyMap[keyContent] = makeContentSchemaMap(resp.Content)
 
-		responsesMap[resp.Code] = codeBodyMap
+		responsesMap[fmt.Sprintf("%d", resp.Code)] = codeBodyMap
 	}
 
 	return responsesMap


### PR DESCRIPTION

# Description
This PR is to fix the "mapping key must be a string scalar rather than number" issue.

# Motivation and Context
Using Stoplight Studio to validate the generated document, I found some issues. 

# How This Has Been Tested
Opening the resulting file with Stoplight Studio

# Screenshots
Before:
Note that at lines 42, 58 and 61 the status code are numeric, and it is expected those to be a string
<img width="1559" alt="Captura de Pantalla 2022-08-11 a la(s) 21 25 25" src="https://user-images.githubusercontent.com/15754252/184268977-f3b072d3-403c-45bb-b89f-2cbcda0acf69.png">

After:
The status codes are now strings as expected
<img width="1558" alt="Captura de Pantalla 2022-08-11 a la(s) 21 37 47" src="https://user-images.githubusercontent.com/15754252/184269371-154c3736-d440-4095-885b-cda7571fe3ba.png">



