### PR TITLE
Fix operation "description" must be present and non-empty string.

### DIFF
--- a/build.go
+++ b/build.go
@@ -137,6 +137,7 @@ func makeAllPathsMap(paths *Paths) pathsMap {
 		pathMap[keyTags] = path.Tags
 		pathMap[keySummary] = path.Summary
 		pathMap[keyOperationID] = path.OperationID
+		pathMap[keyDescription] = path.Description
 		pathMap[keySecurity] = makeSecurityMap(&path.Security)
 		pathMap[keyRequestBody] = makeRequestBodyMap(&path.RequestBody)
 		pathMap[keyResponses] = makeResponsesMap(&path.Responses)

--- a/examples/api-documentation.go
+++ b/examples/api-documentation.go
@@ -5,7 +5,7 @@ import "github.com/go-oas/docs"
 func handleCreateUserRoute(oasPathIndex int, oas *docs.OAS) {
 	path := oas.GetPathByIndex(oasPathIndex)
 
-	path.Summary = "Create a new User"
+	path.Description = "Create a new User"
 	path.OperationID = "createUser"
 
 	path.RequestBody = docs.RequestBody{
@@ -34,7 +34,7 @@ func handleCreateUserRoute(oasPathIndex int, oas *docs.OAS) {
 func handleGetUserRoute(oasPathIndex int, oas *docs.OAS) {
 	path := oas.GetPathByIndex(oasPathIndex)
 
-	path.Summary = "Get a User"
+	path.Description = "Get a User"
 	path.OperationID = "getUser"
 	path.RequestBody = docs.RequestBody{}
 	path.Responses = docs.Responses{

--- a/models.go
+++ b/models.go
@@ -98,6 +98,7 @@ type Path struct {
 	HTTPMethod      string           `yaml:"httpMethod"`
 	Tags            []string         `yaml:"tags"`
 	Summary         string           `yaml:"summary"`
+	Description     string           `yaml:"description"`
 	OperationID     string           `yaml:"operationId"`
 	RequestBody     RequestBody      `yaml:"requestBody"`
 	Responses       Responses        `yaml:"responses"`


### PR DESCRIPTION
# Description
This PR is to fix the "Operation "description" must be present and non-empty string." issue.
I'm wondering why we have the [`Summary` field](https://github.com/go-oas/docs/blob/main/models.go#L100), but it's not rendered in the output document.
I didn't try to remove it but just replaced it when rendering for the `Description` new field.

# Motivation and Context
Using Stoplight Studio to validate the generated document, I found some issues.

# How This Has Been Tested
Opening the resulting file with Stoplight Studio

# Screenshots
Before:
<img width="1558" alt="Captura de Pantalla 2022-08-11 a la(s) 22 34 16" src="https://user-images.githubusercontent.com/15754252/184274531-65aae0ec-6cad-4233-9bea-33084f81f183.png">

After:
<img width="1559" alt="Captura de Pantalla 2022-08-11 a la(s) 22 35 02" src="https://user-images.githubusercontent.com/15754252/184274567-3aa2bb13-6cc5-4516-983a-352622af55a7.png">

